### PR TITLE
[WIP] Improve defaults and add configuration options for logged headers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "illuminate/console": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0",
         "illuminate/contracts": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0",
         "illuminate/http": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0",
+        "illuminate/routing": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0",
         "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0",
         "openzipkin/zipkin": "~1.0",
         "psr/http-message": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "illuminate/console": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0",
         "illuminate/contracts": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0",
         "illuminate/http": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0",
+        "illuminate/log": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0",
         "illuminate/routing": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0",
         "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0",
         "openzipkin/zipkin": "~1.0",

--- a/config/tracing.php
+++ b/config/tracing.php
@@ -11,6 +11,10 @@ return [
             //
         ],
 
+        'allowed_headers' => [
+            '*'
+        ],
+
         'payload' => [
             'content_types' => [
                 'application/json',

--- a/config/tracing.php
+++ b/config/tracing.php
@@ -2,9 +2,43 @@
 
 return [
 
+    /*
+    |--------------------------------------------------------------------------
+    | Tracing Driver
+    |--------------------------------------------------------------------------
+    |
+    | If you're a Jaeger user, we recommend you avail of zipkin driver with zipkin
+    | compatible HTTP endpoint. Refer to Jaeger documentation for more details.
+    |
+    | Supported: "zipkin", "null"
+    |
+    */
+
     'driver' => env('TRACING_DRIVER', 'zipkin'),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Service Name
+    |--------------------------------------------------------------------------
+    |
+    | Use this to lookup your application (microservice) on a tracing dashboard.
+    |
+    */
+
     'service_name' => env('TRACING_SERVICE_NAME', 'example'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Middleware
+    |--------------------------------------------------------------------------
+    |
+    | Configure settings for tracing HTTP requests. You can exclude certain paths
+    | from tracing like '/horizon/api/*' (note that we can use wildcards), allow
+    | headers to be logged or hide values for ones that have sensitive info. It
+    | is also possible to specify content types for which you want to log
+    | request and response bodies.
+    |
+    */
 
     'middleware' => [
         'excluded_paths' => [
@@ -15,12 +49,28 @@ return [
             '*'
         ],
 
+        'sensitive_headers' => [
+            //
+        ],
+
         'payload' => [
             'content_types' => [
                 'application/json',
             ],
         ],
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Zipkin
+    |--------------------------------------------------------------------------
+    |
+    | Configure settings for a zipkin driver like whether you want to use
+    | 128-bit Trace IDs and what is the max value size for flushed span
+    | tags in bytes. Values bigger than this amount will be discarded
+    | but you will still see whether certain tag was reported or not.
+    |
+    */
 
     'zipkin' => [
         'host' => env('ZIPKIN_HOST', 'localhost'),

--- a/src/Middleware/TraceRequests.php
+++ b/src/Middleware/TraceRequests.php
@@ -162,7 +162,7 @@ class TraceRequests
 
         $headers->transform(function ($value, $name) use ($normalizedHeaders) {
             return in_array($name, $normalizedHeaders)
-                ? 'This value is hidden because it contains sensitive info'
+                ? ['This value is hidden because it contains sensitive info']
                 : $value;
         });
 

--- a/src/Middleware/TraceRequests.php
+++ b/src/Middleware/TraceRequests.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Config\Repository;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\HeaderBag;
 use Vinelab\Http\Response;
 use Vinelab\Tracing\Contracts\Span;
 use Vinelab\Tracing\Contracts\Tracer;
@@ -65,6 +66,10 @@ class TraceRequests
 
         if ($span) {
             $this->tagResponseData($span, $request, $response);
+
+            if ($request->route()) {
+                $span->setName(sprintf('%s %s', $request->method(), $request->route()->uri()));
+            }
         }
     }
 
@@ -78,7 +83,7 @@ class TraceRequests
         $span->tag('request_method', $request->method());
         $span->tag('request_path', $request->path());
         $span->tag('request_uri', $request->getRequestUri());
-        $span->tag('request_headers', strval($request->headers));
+        $span->tag('request_headers', $this->transformedHeaders($this->filterHeaders($request->headers)));
         $span->tag('request_ip', $request->ip());
 
         if (in_array($request->headers->get('Content_Type'), $this->config->get('tracing.middleware.payload.content_types'))) {
@@ -98,7 +103,7 @@ class TraceRequests
         }
 
         $span->tag('response_status', strval($response->getStatusCode()));
-        $span->tag('response_headers', strval($response->headers));
+        $span->tag('response_headers', $this->transformedHeaders($this->filterHeaders($response->headers)));
 
         if (in_array($response->headers->get('Content_Type'), $this->config->get('tracing.middleware.payload.content_types'))) {
             $span->tag('response_content', $response->content());
@@ -118,5 +123,49 @@ class TraceRequests
         }
 
         return false;
+    }
+
+    /**
+     * @param  HeaderBag  $headers
+     * @return HeaderBag
+     */
+    protected function filterHeaders(HeaderBag $headers): array
+    {
+        $allowedHeaders = $this->config->get('tracing.middleware.allowed_headers');
+
+        if (in_array('*', $allowedHeaders)) {
+            return $headers->all();
+        }
+
+        $whitelist = array_map('strtolower', $allowedHeaders);
+
+        return collect($headers)->filter(function ($value, $name) use ($whitelist) {
+            return in_array($name, $whitelist);
+        })->all();
+    }
+
+    /**
+     * @param  array  $headers
+     * @return string
+     */
+    protected function transformedHeaders(array $headers = []): string
+    {
+        if (!$headers) {
+            return '';
+        }
+
+        ksort($headers);
+        $max = max(array_map('strlen', array_keys($headers))) + 1;
+
+        $content = '';
+        foreach ($headers as $name => $values) {
+            $name = implode('-', array_map('ucfirst', explode('-', $name)));
+
+            foreach ($values as $value) {
+                $content .= sprintf("%-{$max}s %s\r\n", $name.':', $value);
+            }
+        }
+
+        return $content;
     }
 }

--- a/tests/Zipkin/TraceRequestsTest.php
+++ b/tests/Zipkin/TraceRequestsTest.php
@@ -36,7 +36,7 @@ class TraceRequestsTest extends TestCase
             'message' => 'Unprocessable Entity'
         ], 422);
 
-        $middleware = new TraceRequests($tracer, $this->mockConfig([], ['Content-Type']));
+        $middleware = new TraceRequests($tracer, $this->mockConfig([], ['Content-Type', 'user-agent'], ['user-agent']));
         $middleware->handle($request, function ($req) {});
         $middleware->terminate($request, $response);
         $tracer->flush();
@@ -50,6 +50,7 @@ class TraceRequestsTest extends TestCase
             $this->assertEquals('shipments/3242', Arr::get($span, 'tags.request_path'));
             $this->assertEquals('/shipments/3242?token=secret', Arr::get($span, 'tags.request_uri'));
             $this->assertContains('application/json', Arr::get($span, 'tags.request_headers'));
+            $this->assertContains('This value is hidden because it contains sensitive info', Arr::get($span, 'tags.request_headers'));
             $this->assertContains('Catherine Dupuy', Arr::get($span, 'tags.request_input'));
             $this->assertEquals('127.0.0.1', Arr::get($span, 'tags.request_ip'));
 

--- a/tests/Zipkin/TraceRequestsTest.php
+++ b/tests/Zipkin/TraceRequestsTest.php
@@ -85,9 +85,10 @@ class TraceRequestsTest extends TestCase
     /**
      * @param  array  $excludedPaths
      * @param  array  $allowedHeaders
+     * @param  array  $sensitiveHeaders
      * @return Repository|Mockery\LegacyMockInterface|Mockery\MockInterface
      */
-    protected function mockConfig(array $excludedPaths = [], $allowedHeaders = [])
+    protected function mockConfig(array $excludedPaths = [], $allowedHeaders = [], array $sensitiveHeaders = [])
     {
         $config = Mockery::mock(Repository::class);
         $config->shouldReceive('get')
@@ -101,6 +102,10 @@ class TraceRequestsTest extends TestCase
         $config->shouldReceive('get')
             ->with('tracing.middleware.allowed_headers')
             ->andReturn($allowedHeaders);
+
+        $config->shouldReceive('get')
+            ->with('tracing.middleware.sensitive_headers')
+            ->andReturn($sensitiveHeaders);
 
         return $config;
     }


### PR DESCRIPTION
Resolves https://github.com/Vinelab/tracing-laravel/issues/6

Addressed:
- better default span names for HTTP tracing like `VERB /path/for/route`
- ability to whitelist headers for logging (or use wildcard like `*` to log everything)
- ability to mark headers as sensitive in order to hide their values

Additional improvements:
- Automatically tag error spans using `MessageLogged` event