### PR TITLE
Changed $config to protected in TracingDriverManager

### DIFF
--- a/src/TracingDriverManager.php
+++ b/src/TracingDriverManager.php
@@ -13,7 +13,7 @@ class TracingDriverManager extends Manager
     /**
      * @var Repository
      */
-    private $config;
+    protected $config;
 
     /**
      * EngineManager constructor.


### PR DESCRIPTION
Fixed error in Laravel 6

PHP Fatal error:  Access level to Vinelab\Tracing\TracingDriverManager::$config must be protected (as in class Illuminate\Support\Manager) or weaker in /Users/deonvdv/Sites/thryv-leads/app/vendor/vinelab/tracing-laravel/src/TracingDriverManager.php on line 11