### PR TITLE
Add error message to traces

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.7'
+
+services:
+  # Docker Image: https://hub.docker.com/r/vinelab/nginx-php
+  app:
+    image: vinelab/nginx-php:composer
+    volumes:
+      - ./:/code:cached

--- a/src/Listeners/QueueJobSubscriber.php
+++ b/src/Listeners/QueueJobSubscriber.php
@@ -95,6 +95,7 @@ class QueueJobSubscriber
         if ($this->app->has('tracing.queue.span')) {
             if ($event instanceof JobFailed) {
                 $this->app->get('tracing.queue.span')->tag('error', 'true');
+                $this->app->get('tracing.queue.span')->tag('error_message', $event->exception->getMessage());
             }
 
             $this->app->get('tracing.queue.span')->finish();

--- a/src/TracingServiceProvider.php
+++ b/src/TracingServiceProvider.php
@@ -47,6 +47,7 @@ class TracingServiceProvider extends ServiceProvider
             $this->app['events']->listen(MessageLogged::class, function (MessageLogged $event) {
                 if ($event->level == 'error') {
                     optional(Trace::getRootSpan())->tag('error', 'true');
+                    optional(Trace::getRootSpan())->tag('error_message', $event->message);
                 }
             });
         }

--- a/tests/Zipkin/QueueJobSubscriberTest.php
+++ b/tests/Zipkin/QueueJobSubscriberTest.php
@@ -127,6 +127,7 @@ class QueueJobSubscriberTest extends TestCase
                 ],
             ], json_decode(Arr::get($span, 'tags.job_input'), true));
             $this->assertEquals('true', Arr::get($span, 'tags.error'));
+            $this->assertEquals('whatever', Arr::get($span, 'tags.error_message'));
 
             return true;
         }));

--- a/tests/Zipkin/TraceRequestsTest.php
+++ b/tests/Zipkin/TraceRequestsTest.php
@@ -44,7 +44,7 @@ class TraceRequestsTest extends TestCase
         $reporter->shouldHaveReceived('report')->with(Mockery::on(function ($spans) {
             $span = $this->shiftSpan($spans);
 
-            $this->assertEquals('POST shipments/{id}', Arr::get($span, 'name'));
+            $this->assertEquals('POST /shipments/{id}', Arr::get($span, 'name'));
             $this->assertEquals('http', Arr::get($span, 'tags.type'));
             $this->assertEquals('POST', Arr::get($span, 'tags.request_method'));
             $this->assertEquals('shipments/3242', Arr::get($span, 'tags.request_path'));


### PR DESCRIPTION
Add `error_message` tag to failed jobs traces, with either:
* The `\Exception` message in case of a queued job.
* The `Illuminate\Log\Events\MessageLogged` message in the rest of the cases.