### PR TITLE
Added timestamp parameter on start/finish span

### DIFF
--- a/src/Contracts/Span.php
+++ b/src/Contracts/Span.php
@@ -24,8 +24,9 @@ interface Span
      * Notify that operation has finished.
      * Span duration is derived by subtracting the start
      * timestamp from this, and set when appropriate.
+     * @param int|null $timestamp
      */
-    public function finish(): void;
+    public function finish($timestamp = null): void;
 
     /**
      * Associates an event that explains latency with a timestamp.

--- a/src/Contracts/Tracer.php
+++ b/src/Contracts/Tracer.php
@@ -11,11 +11,12 @@ interface Tracer
      *
      * If parent context does not contain a trace, a new trace will be implicitly created.
      *
-     * @param  string  $name
-     * @param  SpanContext|null  $spanContext
+     * @param string $name
+     * @param SpanContext|null $spanContext
+     * @param int|null $timestamp
      * @return Span
      */
-    public function startSpan(string $name, SpanContext $spanContext = null): Span;
+    public function startSpan(string $name, SpanContext $spanContext = null, $timestamp = null): Span;
 
     /**
      * Retrieve the root span of the service

--- a/src/Drivers/Null/NullSpan.php
+++ b/src/Drivers/Null/NullSpan.php
@@ -44,8 +44,9 @@ class NullSpan implements Span
      * Notify that operation has finished.
      * Span duration is derived by subtracting the start
      * timestamp from this, and set when appropriate.
+     * @param int|null $timestamp
      */
-    public function finish(): void
+    public function finish($timestamp = null): void
     {
         //
     }

--- a/src/Drivers/Null/NullTracer.php
+++ b/src/Drivers/Null/NullTracer.php
@@ -27,11 +27,12 @@ class NullTracer implements Tracer
      *
      * If parent context does not contain a trace, a new trace will be implicitly created.
      *
-     * @param  string  $name
-     * @param  SpanContext|null  $spanContext
+     * @param string $name
+     * @param SpanContext|null $spanContext
+     * @param int|null $timestamp
      * @return Span
      */
-    public function startSpan(string $name, ?SpanContext $spanContext = null): Span
+    public function startSpan(string $name, SpanContext $spanContext = null, $timestamp = null): Span
     {
         if ($this->rootSpan) {
             $span = new NullSpan(false);

--- a/src/Drivers/Null/NullTracer.php
+++ b/src/Drivers/Null/NullTracer.php
@@ -32,7 +32,7 @@ class NullTracer implements Tracer
      * @param int|null $timestamp
      * @return Span
      */
-    public function startSpan(string $name, SpanContext $spanContext = null, $timestamp = null): Span
+    public function startSpan(string $name, ?SpanContext $spanContext = null, $timestamp = null): Span
     {
         if ($this->rootSpan) {
             $span = new NullSpan(false);

--- a/src/Drivers/Zipkin/ZipkinSpan.php
+++ b/src/Drivers/Zipkin/ZipkinSpan.php
@@ -60,10 +60,11 @@ class ZipkinSpan implements Span
      * Notify that operation has finished.
      * Span duration is derived by subtracting the start
      * timestamp from this, and set when appropriate.
+     * @param int|null $timestamp
      */
-    public function finish(): void
+    public function finish($timestamp = null): void
     {
-        $this->span->finish();
+        $this->span->finish($timestamp);
     }
 
     /**

--- a/src/Drivers/Zipkin/ZipkinTracer.php
+++ b/src/Drivers/Zipkin/ZipkinTracer.php
@@ -170,11 +170,12 @@ class ZipkinTracer implements Tracer
      * The first span you create in the service will be considered the root span. Calling
      * flush {@see ZipkinTracer::flush()} will unset the root span along with request uuid.
      *
-     * @param  string  $name
-     * @param  SpanContext|null  $spanContext
+     * @param string $name
+     * @param SpanContext|null $spanContext
+     * @param int|null $timestamp
      * @return Span
      */
-    public function startSpan(string $name, ?SpanContext $spanContext = null): Span
+    public function startSpan(string $name, ?SpanContext $spanContext = null, $timestamp = null): Span
     {
         $rawSpan = $this->tracing->getTracer()->nextSpan($spanContext ? $spanContext->getRawContext() : null);
 
@@ -191,7 +192,7 @@ class ZipkinTracer implements Tracer
         $this->currentSpan = $span;
         $span->setName($name);
 
-        $rawSpan->start();
+        $rawSpan->start($timestamp);
 
         return $span;
     }

--- a/src/Facades/Trace.php
+++ b/src/Facades/Trace.php
@@ -12,7 +12,7 @@ use Vinelab\Tracing\Contracts\Tracer;
 /**
  * @see \Vinelab\Tracing\Contracts\Tracer
  *
- * @method static Span startSpan(string $name, SpanContext $spanContext = null)
+ * @method static Span startSpan(string $name, SpanContext $spanContext = null, $timestamp = null)
  * @method static Span getRootSpan()
  * @method static Span getCurrentSpan()
  * @method static string|null getUUID()


### PR DESCRIPTION
Laravel has profiling events only after query executed. I did this because i need to trace db queries
```php
        DB::listen(function ($query) {
            $span = Trace::startSpan('db-query', Trace::getCurrentSpan()->getContext(), \Zipkin\Timestamp\now() - (int)($query->time * 100) * 1000 / 100);
            $span->tag('query', $query->sql);
            $span->tag('time', $query->time);
            $span->tag('connectionName', $query->connectionName);
            $span->finish();
        });
```