### PR TITLE
Allow to explicitly pass timestamps when creating/finishing spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ use Vinelab\Tracing\Contracts\Injector;
 use Vinelab\Tracing\Contracts\Span;
 use Vinelab\Tracing\Contracts\SpanContext;
 
-public function startSpan(string $name, SpanContext $spanContext = null): Span;
+public function startSpan(string $name, SpanContext $spanContext = null, ?int $timestamp = null): Span;
 public function getRootSpan(): ?Span;
 public function getCurrentSpan(): ?Span;
 public function getUUID(): ?string;

--- a/src/Contracts/Span.php
+++ b/src/Contracts/Span.php
@@ -24,9 +24,10 @@ interface Span
      * Notify that operation has finished.
      * Span duration is derived by subtracting the start
      * timestamp from this, and set when appropriate.
-     * @param int|null $timestamp
+     *
+     * @param int|null $timestamp  intval(microtime(true) * 1000000)
      */
-    public function finish($timestamp = null): void;
+    public function finish(?int $timestamp = null): void;
 
     /**
      * Associates an event that explains latency with a timestamp.

--- a/src/Contracts/Span.php
+++ b/src/Contracts/Span.php
@@ -24,8 +24,9 @@ interface Span
      * Notify that operation has finished.
      * Span duration is derived by subtracting the start
      * timestamp from this, and set when appropriate.
+     * @param int|null $timestamp
      */
-    public function finish(): void;
+    public function finish($timestamp = null): void;
 
     /**
      * Associates an event that explains latency with a timestamp.

--- a/src/Contracts/Tracer.php
+++ b/src/Contracts/Tracer.php
@@ -11,11 +11,12 @@ interface Tracer
      *
      * If parent context does not contain a trace, a new trace will be implicitly created.
      *
-     * @param  string  $name
-     * @param  SpanContext|null  $spanContext
+     * @param string $name
+     * @param SpanContext|null $spanContext
+     * @param int|null $timestamp
      * @return Span
      */
-    public function startSpan(string $name, SpanContext $spanContext = null): Span;
+    public function startSpan(string $name, SpanContext $spanContext = null, $timestamp = null): Span;
 
     /**
      * Retrieve the root span of the service

--- a/src/Contracts/Tracer.php
+++ b/src/Contracts/Tracer.php
@@ -13,10 +13,10 @@ interface Tracer
      *
      * @param string $name
      * @param SpanContext|null $spanContext
-     * @param int|null $timestamp
+     * @param int|null $timestamp  intval(microtime(true) * 1000000)
      * @return Span
      */
-    public function startSpan(string $name, SpanContext $spanContext = null, $timestamp = null): Span;
+    public function startSpan(string $name, SpanContext $spanContext = null, ?int $timestamp = null): Span;
 
     /**
      * Retrieve the root span of the service

--- a/src/Drivers/Null/NullSpan.php
+++ b/src/Drivers/Null/NullSpan.php
@@ -44,9 +44,10 @@ class NullSpan implements Span
      * Notify that operation has finished.
      * Span duration is derived by subtracting the start
      * timestamp from this, and set when appropriate.
-     * @param int|null $timestamp
+     *
+     * @param int|null $timestamp  intval(microtime(true) * 1000000)
      */
-    public function finish($timestamp = null): void
+    public function finish(?int $timestamp = null): void
     {
         //
     }

--- a/src/Drivers/Null/NullSpan.php
+++ b/src/Drivers/Null/NullSpan.php
@@ -44,8 +44,9 @@ class NullSpan implements Span
      * Notify that operation has finished.
      * Span duration is derived by subtracting the start
      * timestamp from this, and set when appropriate.
+     * @param int|null $timestamp
      */
-    public function finish(): void
+    public function finish($timestamp = null): void
     {
         //
     }

--- a/src/Drivers/Null/NullTracer.php
+++ b/src/Drivers/Null/NullTracer.php
@@ -27,11 +27,12 @@ class NullTracer implements Tracer
      *
      * If parent context does not contain a trace, a new trace will be implicitly created.
      *
-     * @param  string  $name
-     * @param  SpanContext|null  $spanContext
+     * @param string $name
+     * @param SpanContext|null $spanContext
+     * @param int|null $timestamp
      * @return Span
      */
-    public function startSpan(string $name, ?SpanContext $spanContext = null): Span
+    public function startSpan(string $name, SpanContext $spanContext = null, $timestamp = null): Span
     {
         if ($this->rootSpan) {
             $span = new NullSpan(false);

--- a/src/Drivers/Null/NullTracer.php
+++ b/src/Drivers/Null/NullTracer.php
@@ -29,10 +29,10 @@ class NullTracer implements Tracer
      *
      * @param string $name
      * @param SpanContext|null $spanContext
-     * @param int|null $timestamp
+     * @param int|null $timestamp  intval(microtime(true) * 1000000)
      * @return Span
      */
-    public function startSpan(string $name, ?SpanContext $spanContext = null, $timestamp = null): Span
+    public function startSpan(string $name, ?SpanContext $spanContext = null, ?int $timestamp = null): Span
     {
         if ($this->rootSpan) {
             $span = new NullSpan(false);

--- a/src/Drivers/Null/NullTracer.php
+++ b/src/Drivers/Null/NullTracer.php
@@ -32,7 +32,7 @@ class NullTracer implements Tracer
      * @param int|null $timestamp
      * @return Span
      */
-    public function startSpan(string $name, SpanContext $spanContext = null, $timestamp = null): Span
+    public function startSpan(string $name, ?SpanContext $spanContext = null, $timestamp = null): Span
     {
         if ($this->rootSpan) {
             $span = new NullSpan(false);

--- a/src/Drivers/Zipkin/ZipkinSpan.php
+++ b/src/Drivers/Zipkin/ZipkinSpan.php
@@ -60,10 +60,11 @@ class ZipkinSpan implements Span
      * Notify that operation has finished.
      * Span duration is derived by subtracting the start
      * timestamp from this, and set when appropriate.
+     * @param int|null $timestamp
      */
-    public function finish(): void
+    public function finish($timestamp = null): void
     {
-        $this->span->finish();
+        $this->span->finish($timestamp);
     }
 
     /**

--- a/src/Drivers/Zipkin/ZipkinSpan.php
+++ b/src/Drivers/Zipkin/ZipkinSpan.php
@@ -60,9 +60,10 @@ class ZipkinSpan implements Span
      * Notify that operation has finished.
      * Span duration is derived by subtracting the start
      * timestamp from this, and set when appropriate.
-     * @param int|null $timestamp
+     *
+     * @param int|null $timestamp  intval(microtime(true) * 1000000)
      */
-    public function finish($timestamp = null): void
+    public function finish(?int $timestamp = null): void
     {
         $this->span->finish($timestamp);
     }

--- a/src/Drivers/Zipkin/ZipkinTracer.php
+++ b/src/Drivers/Zipkin/ZipkinTracer.php
@@ -170,11 +170,12 @@ class ZipkinTracer implements Tracer
      * The first span you create in the service will be considered the root span. Calling
      * flush {@see ZipkinTracer::flush()} will unset the root span along with request uuid.
      *
-     * @param  string  $name
-     * @param  SpanContext|null  $spanContext
+     * @param string $name
+     * @param SpanContext|null $spanContext
+     * @param int|null $timestamp
      * @return Span
      */
-    public function startSpan(string $name, ?SpanContext $spanContext = null): Span
+    public function startSpan(string $name, ?SpanContext $spanContext = null, $timestamp = null): Span
     {
         $rawSpan = $this->tracing->getTracer()->nextSpan($spanContext ? $spanContext->getRawContext() : null);
 
@@ -191,7 +192,7 @@ class ZipkinTracer implements Tracer
         $this->currentSpan = $span;
         $span->setName($name);
 
-        $rawSpan->start();
+        $rawSpan->start($timestamp);
 
         return $span;
     }

--- a/src/Drivers/Zipkin/ZipkinTracer.php
+++ b/src/Drivers/Zipkin/ZipkinTracer.php
@@ -172,10 +172,10 @@ class ZipkinTracer implements Tracer
      *
      * @param string $name
      * @param SpanContext|null $spanContext
-     * @param int|null $timestamp
+     * @param int|null $timestamp  intval(microtime(true) * 1000000)
      * @return Span
      */
-    public function startSpan(string $name, ?SpanContext $spanContext = null, $timestamp = null): Span
+    public function startSpan(string $name, ?SpanContext $spanContext = null, ?int $timestamp = null): Span
     {
         $rawSpan = $this->tracing->getTracer()->nextSpan($spanContext ? $spanContext->getRawContext() : null);
 

--- a/src/Facades/Trace.php
+++ b/src/Facades/Trace.php
@@ -12,7 +12,7 @@ use Vinelab\Tracing\Contracts\Tracer;
 /**
  * @see \Vinelab\Tracing\Contracts\Tracer
  *
- * @method static Span startSpan(string $name, SpanContext $spanContext = null)
+ * @method static Span startSpan(string $name, SpanContext $spanContext = null, $timestamp = null)
  * @method static Span getRootSpan()
  * @method static Span getCurrentSpan()
  * @method static string|null getUUID()

--- a/src/Facades/Trace.php
+++ b/src/Facades/Trace.php
@@ -12,7 +12,7 @@ use Vinelab\Tracing\Contracts\Tracer;
 /**
  * @see \Vinelab\Tracing\Contracts\Tracer
  *
- * @method static Span startSpan(string $name, SpanContext $spanContext = null, $timestamp = null)
+ * @method static Span startSpan(string $name, SpanContext $spanContext = null, ?int $timestamp = null)
  * @method static Span getRootSpan()
  * @method static Span getCurrentSpan()
  * @method static string|null getUUID()


### PR DESCRIPTION
closes #18 

---

Based on [original PR](https://github.com/Vinelab/tracing-laravel/pull/19) from @ujin001, but with couple minor improvements like tests and documentation.

Also, I advise to create timestamp using something driver-agnostic like in examples below:

```php
intval(microtime(true) * 1000000);
intval(now()->getPreciseTimestamp());
```

`\Zipkin\Timestamp\now()` is a method specific to Zipkin instrumentation and may lead to issue in case we update underlying instrumentation or you decide to switch driver.

Note that this does not affect existing users of the library. You may continue to rely on implicit timestamps as before.