### PR TITLE
Add middleware config to hide sensitive HTTP input

### DIFF
--- a/config/tracing.php
+++ b/config/tracing.php
@@ -53,6 +53,10 @@ return [
             //
         ],
 
+        'sensitive_input' => [
+            //
+        ],
+
         'payload' => [
             'content_types' => [
                 'application/json',


### PR DESCRIPTION
Provides a mechanism for applications to hide sensitive HTTP input, in a similar fashion to how sensitive headers are handled.