### PR TITLE
Add Lumen support

### DIFF
--- a/src/TracingServiceProvider.php
+++ b/src/TracingServiceProvider.php
@@ -22,7 +22,7 @@ class TracingServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        if ($this->app->runningInConsole()) {
+        if ($this->app->runningInConsole() && function_exists('config_path')) {
             $this->publishes([
                 __DIR__.'/../config/tracing.php' => config_path('tracing.php'),
             ]);
@@ -52,10 +52,12 @@ class TracingServiceProvider extends ServiceProvider
             });
         }
 
-        $this->app->terminating(function () {
-            optional(Trace::getRootSpan())->finish();
-            Trace::flush();
-        });
+        if (method_exists($this->app, 'terminating')) {
+            $this->app->terminating(function () {
+                optional(Trace::getRootSpan())->finish();
+                Trace::flush();
+            });
+        }
     }
 
     /**


### PR DESCRIPTION
This PR resolves #30. No breaking changes.

After some investigation I decided to add support for Lumen since it's fairy trivial to maintain. Note that Lumen won't avail of all the features of this package because it doesn't have some events and terminating callbacks. This means that some use cases will require a more "manual" approach when creating traces. I included all the necessary information in the README.