### PR TITLE
Fix TraceRequests using arrow function

### DIFF
--- a/src/Middleware/TraceRequests.php
+++ b/src/Middleware/TraceRequests.php
@@ -256,7 +256,7 @@ class TraceRequests
     {
         $replaceMap = array_combine(
             array_values($parameters),
-            array_map(fn ($v) => '{'.$v.'}', array_keys($parameters))
+            array_map(function ($v) { return '{'.$v.'}'; }, array_keys($parameters))
         );
 
         return strtr($path, $replaceMap);


### PR DESCRIPTION
TraceRequests is using arrow function that is only available on php >= 7.4. This commit changed it to use anonymous function.