### PR TITLE
Fix compatibility with Zipkin 3

### DIFF
--- a/src/Drivers/Zipkin/ZipkinTracer.php
+++ b/src/Drivers/Zipkin/ZipkinTracer.php
@@ -320,7 +320,7 @@ class ZipkinTracer implements Tracer
     protected function createReporter(): Reporter
     {
         if (!$this->reporter) {
-            return new HttpReporter(null, [
+            return new HttpReporter([
                 'endpoint_url' => sprintf('http://%s:%s/api/v2/spans', $this->host, $this->port),
                 'timeout' => $this->requestTimeout,
             ]);


### PR DESCRIPTION
#34 introduced PHP 8 support which requires Zipkin PHP v3. 

However, due to slight difference in contracts the package can't instantiate the Http reporter:

```
PHP Fatal error:  Uncaught TypeError: Zipkin\Reporters\Http::__construct(): Argument #1 ($options) must be of type array, null given, called in /opt/project/vendor/vinelab/tracing-laravel/src/Drivers/Zipkin/ZipkinTracer.php on line 325 and defined in /opt/project/vendor/openzipkin/zipkin/src/Zipkin/Reporters/Http.php:52
Stack trace:
```

It seems like the suggested order of parameters was changed back in v2, but it didn't become an issue due to [additional layer of compatibility checks](https://github.com/openzipkin/zipkin-php/blob/e33b25412a6ad69b41d28f582f7166620783acab/src/Zipkin/Reporters/Http.php#L85) which are now removed.   This will now work for both v2 and v3.