### PR TITLE
Fix QueryJobSubscribe if JobInstance is null

### DIFF
--- a/src/Listeners/QueueJobSubscriber.php
+++ b/src/Listeners/QueueJobSubscriber.php
@@ -70,7 +70,7 @@ class QueueJobSubscriber
         /** @var mixed $jobInstance */
         $jobInstance = unserialize(Arr::get($job->payload(), 'data.command'));
 
-        if (in_array(ShouldBeTraced::class, class_implements($jobInstance))) {
+        if ($jobInstance && in_array(ShouldBeTraced::class, class_implements($jobInstance))) {
             $jobInput = $this->retrieveQueueJobInput($jobInstance);
 
             /** @var Span $span */


### PR DESCRIPTION
I use laravel-tracing with lumen in a microservices environment. I tried to push queue from service A to service B with the following code:

`Queue::connection('transaction_queue')->pushOn('transactions', 'App\Jobs\ProcessTransactions@handle', $payload);`

But I got an exception in 

`class_implements(): object or string expected {"exception":"[object] (ErrorException(code: 0): class_implements(): object or string expected at /var/www/vendor/vinelab/tracing-laravel/src/Listeners/QueueJobSubscriber.php:73)`

because the queue does not include `data.command` payload.
This fix is to ignore queue if data.command is not found.