### PR TITLE
Tag span with laravel_action only when route exists

### DIFF
--- a/src/Middleware/TraceRequests.php
+++ b/src/Middleware/TraceRequests.php
@@ -237,7 +237,7 @@ class TraceRequests
      */
     protected function isLaravelRoute($route): bool
     {
-        return method_exists($route, 'uri');
+        return $route && method_exists($route, 'uri');
     }
 
     /**

--- a/src/Middleware/TraceRequests.php
+++ b/src/Middleware/TraceRequests.php
@@ -106,8 +106,10 @@ class TraceRequests
      */
     protected function tagResponseData(Span $span, Request $request, $response): void
     {
-        if (method_exists($request->route(), 'getActionName')) {
-            $span->tag('laravel_action', $request->route()->getActionName());
+        if ($route = $request->route()) {
+            if (method_exists($route, 'getActionName')) {
+                $span->tag('laravel_action', $route->getActionName());
+            }
         }
 
         $span->tag('response_status', strval($response->getStatusCode()));


### PR DESCRIPTION
This prevents `TypeError: method_exists(): Argument #1 ($object_or_class) must be of type object|string, null given` when trying to tag a request for a route that does not exist.