### PR TITLE
Allow span 'kind' to be set (e.g. CLIENT|SERVER|CONSUMER|PRODUCER)

### DIFF
--- a/src/Contracts/Tracer.php
+++ b/src/Contracts/Tracer.php
@@ -16,7 +16,7 @@ interface Tracer
      * @param int|null $timestamp  intval(microtime(true) * 1000000)
      * @return Span
      */
-    public function startSpan(string $name, SpanContext $spanContext = null, ?int $timestamp = null): Span;
+    public function startSpan(string $name, SpanContext $spanContext = null, ?int $timestamp = null, $kind = null): Span;
 
     /**
      * Retrieve the root span of the service

--- a/src/Contracts/Tracer.php
+++ b/src/Contracts/Tracer.php
@@ -14,9 +14,10 @@ interface Tracer
      * @param string $name
      * @param SpanContext|null $spanContext
      * @param int|null $timestamp  intval(microtime(true) * 1000000)
+     * @param string|null $kind
      * @return Span
      */
-    public function startSpan(string $name, SpanContext $spanContext = null, ?int $timestamp = null, $kind = null): Span;
+    public function startSpan(string $name, SpanContext $spanContext = null, ?int $timestamp = null, ?string $kind = null): Span;
 
     /**
      * Retrieve the root span of the service

--- a/src/Drivers/Zipkin/ZipkinTracer.php
+++ b/src/Drivers/Zipkin/ZipkinTracer.php
@@ -181,11 +181,15 @@ class ZipkinTracer implements Tracer
      * @param string $name
      * @param SpanContext|null $spanContext
      * @param int|null $timestamp  intval(microtime(true) * 1000000)
+     * @param string|null $kind
      * @return Span
      */
-    public function startSpan(string $name, ?SpanContext $spanContext = null, ?int $timestamp = null): Span
+    public function startSpan(string $name, ?SpanContext $spanContext = null, ?int $timestamp = null, ?string $kind = null): Span
     {
         $rawSpan = $this->tracing->getTracer()->nextSpan($spanContext ? $spanContext->getRawContext() : null);
+        if ($kind) {
+            $rawSpan->setKind($kind);
+        }
 
         if ($this->rootSpan) {
             $span = new ZipkinSpan($rawSpan, false);

--- a/src/Facades/Trace.php
+++ b/src/Facades/Trace.php
@@ -12,7 +12,7 @@ use Vinelab\Tracing\Contracts\Tracer;
 /**
  * @see \Vinelab\Tracing\Contracts\Tracer
  *
- * @method static Span startSpan(string $name, SpanContext $spanContext = null, ?int $timestamp = null)
+ * @method static Span startSpan(string $name, SpanContext $spanContext = null, ?int $timestamp = null, $kind = null)
  * @method static Span getRootSpan()
  * @method static Span getCurrentSpan()
  * @method static string|null getUUID()

--- a/src/Middleware/TraceRequests.php
+++ b/src/Middleware/TraceRequests.php
@@ -49,7 +49,7 @@ class TraceRequests
         if (!$this->shouldBeExcluded($request->path())) {
             $spanContext = $this->tracer->extract($request, Formats::ILLUMINATE_HTTP);
 
-            $span = $this->tracer->startSpan('Http Request', $spanContext);
+            $span = $this->tracer->startSpan('Http Request', $spanContext, null, \Zipkin\Kind\SERVER);
 
             $this->tagRequestData($span, $request);
         }


### PR DESCRIPTION
The goal here is to be able to identify spans as either 'CLIENT', 'SERVER', 'CONSUMER', or 'PRODUCER' - such that their relationships on a service graph can be mapped, like this:

![Screenshot 2024-02-04 at 6 20 39 PM](https://github.com/Vinelab/tracing-laravel/assets/41700854/21ba3eb6-7865-4880-a04e-3975d97f9bf5)

Since the package doesn't have a Guzzle outbound HTTP request, you only see the 'SERVER' implementation of this new "kind" that can be set on the raw span.